### PR TITLE
Adding internal IDs to listcateogries

### DIFF
--- a/pages/api/categories/ListCategories.js
+++ b/pages/api/categories/ListCategories.js
@@ -18,10 +18,16 @@ export default async function(req,res) {
   return new Promise((resolve, reject) => {
     
     firebase.database()
-      .ref('/category/')
+      .ref('/category')
       .once('value', snapshot => {
         res.status(200);
-        res.json({"categories": Object.values(snapshot.val())})
+        var categories = []
+        snapshot.forEach(child => {
+          var cat = child.val()
+          cat["id"] = child.key
+          categories.push(cat)
+        })
+        res.json({"categories": categories})
         return resolve();
       })  
       .catch(function(error){


### PR DESCRIPTION
Adds internal IDs to listcategories endpoint. Return data looks like

[ { displayName: 'Frozen Foods', iconName: 'snowflake', id: '8WeYr8bkRO' },
  { displayName: 'Hi', iconName: 'help', id: '8sJAdmGbnB' },
  { displayName: 'NewCat', iconName: 'OSKI', id: 'Gag0ISHQYQ' },
  { displayName: 'Sauces', iconName: 'soy-sauce',id: 'PIXafWlKvP' },
  { displayName: 'Protein', iconName: 'egg', id: 'TseGVAeF75' },
  { displayName: 'beverages', iconName: 'cup', id: 'd5FIKJ9Ie2' },
  { displayName: 'Grains', iconName: 'barley', id: 'kVsxgN0G1L' },
  { displayName: 'Snacks', iconName: 'food', id: 'oqKrrGDL8b' },
  { displayName: 'Spices', iconName: 'grain', id: 'qbTAl86aC2' },
  { displayName: 'Canned Foods', iconName: 'window-open',id: 'rhCZvi0hp4' } ]