### PR TITLE
store counts as integers in firebase database

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,9 +3,7 @@ import "../styles/index.css"
 import App from 'next/app'
 import cookies from 'next-cookies'
 
-const dev = process.env.NODE_ENV === 'development';
-const server = dev ? 'http://localhost:3000' : 'https://testcalnourish.com/';
-
+const server = process.env.VERCEL_URL;
 
 // Custom App to wrap it with context provider
 export default function MyApp({ Component, pageProps }) {

--- a/pages/api/inventory/AddItem.js
+++ b/pages/api/inventory/AddItem.js
@@ -3,7 +3,7 @@ import {validateFunc} from '../validate'
 
 /*
 * /api/inventory/AddItem
-* req.body = {string barcode, string array categoryName, string count, 
+* req.body = {string barcode, string array categoryName, string/int count, 
               string itemName, default string lowStock = "-1", default string packSize = "1"}
 * every field is required except for lowStock and packsize
 * categoryName is an array of internal category IDs
@@ -25,6 +25,12 @@ function requireParams(body, res) {
         console.log("Not ok1")
         res.status(400).json({error: "missing barcode||count||itemName in request"});
     }
+
+    if (isNaN(parseInt(body.count))) {
+        console.log("Invalid count (not a number)");
+        res.status(400).json({error: "invalid count (not a number)"});
+    }
+
     // require categories obj with at least one entry
     if (!body.categoryName || body.categoryName.length < 1) {
         console.log("Not ok2")
@@ -57,7 +63,7 @@ export default async function(req,res) {
         let barcode = body.barcode.toString();
         let newItem = {};
         newItem["barcode"] = barcode;
-        newItem["count"] = body.count.toString();
+        newItem["count"] = parseInt(body.count);
         newItem["itemName"] = body.itemName;
         newItem["categoryName"] = Object.keys(body.categoryName); // get it in array format
         newItem["lowStock"] = body.lowStock ? body.lowStock.toString() : "-1";

--- a/pages/api/inventory/UpdateItem.js
+++ b/pages/api/inventory/UpdateItem.js
@@ -3,7 +3,7 @@ import {validateFunc} from '../validate'
 
 /*
 * /api/inventory/UpdateItem
-* req.body = {string barcode, string array categoryName, string count, 
+* req.body = {string barcode, string array categoryName, string/int count, 
               string itemName, string lowStock, string packSize}
 */
 
@@ -14,8 +14,6 @@ export const config = {
     bodyParser: true,
   },
 }
-
-
 
 export default async function(req,res) {   
   // verify this request is legit
@@ -43,6 +41,14 @@ export default async function(req,res) {
     let updatedFields = {};
     // make sure barcode is a string
     let barcode = body.barcode.toString();
+    // convert count to integer
+    if (body["count"]) {
+      body["count"] = parseInt(body["count"]);
+      if (isNaN(body["count"])) {
+        res.status(400).json({error: "invalid count (not a number)"});
+        return resolve();
+      }
+    }
 
     FIELDS.forEach(field => {
       if (body[field]) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,6 +10,19 @@ import cookie from 'js-cookie';
 // fetcher for get requests
 const fetcher = (url) => fetch(url).then((res) => res.json())
 
+function fixCounts() {
+    const token = cookie.get("firebaseToken")
+    fetch('/api/inventory/GetAllItems', { method: 'GET', headers: {'Content-Type': "application/json"}})
+    .then(response => response.json())
+    .then(data => {
+        for (var bcode in data) {
+            fetch('/api/inventory/UpdateItem', { method: 'POST', body: 
+                JSON.stringify({"barcode" : bcode, "count": data[bcode]["count"]}),
+                headers: {'Content-Type': "application/json", 'Authorization': token}})
+        }
+    });
+}
+
 export default function Home() {
   // Our custom hook to get context values
   const { user, setUser, googleLogin } = useUser()
@@ -65,7 +78,7 @@ export default function Home() {
                   "itemName": "API Testing Item",
                   "packSize": "31",
                   "lowStock": "2",
-                  "categoryName": {"PIXafWlKvP": "PIXafWlKvP", "kVsxgN0G1L": "kVsxgN0G1L"},
+                  "categoryName": {"547G7Gnikt": "547G7Gnikt"},
                   "count": "400"
                 }),
                 headers: {'Content-Type': "application/json", 'Authorization': token}})
@@ -99,6 +112,12 @@ export default function Home() {
           fetch('/api/categories/ListCategories', { method: 'GET',
                 headers: {'Content-Type': "application/json"}})
         }}> ListCategories Button </button>
+      </td></tr>
+
+      <tr><td>
+        <button onClick={() => {
+          fixCounts();
+        }}> fix count field </button>
       </td></tr>
     </table>
     </Layout>


### PR DESCRIPTION
1. modifies `addItem` and `updateItem` API's to store counts as integers (instead of strings)
2. adds button to index.js that runs script to convert currently stored item counts to integers