### PR TITLE
GetOrdersByStatus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2894,6 +2894,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -4577,6 +4586,12 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -6436,6 +6451,12 @@
         "react": "^16.7.0",
         "react-dom": "^16.7.0"
       }
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.16",
@@ -10229,7 +10250,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/pages/api/orders/GetOrdersByStatus.js
+++ b/pages/api/orders/GetOrdersByStatus.js
@@ -50,7 +50,7 @@ export default async function(req,res) {
         return firebase.auth().signInAnonymously()
             .then(() => {
                 var ref = firebase.database().ref("/order");                
-                ref.orderByChild("status").equalTo(ORDER_STATUS_OPEN).once("value", snapshot => {
+                ref.orderByChild("status").equalTo(query["status"]).once("value", snapshot => {
                     const orders = snapshot.toJSON();
                     res.status(200).json(orders);
                     return;

--- a/pages/api/orders/GetOrdersByStatus.js
+++ b/pages/api/orders/GetOrdersByStatus.js
@@ -1,6 +1,8 @@
 import firebase from '../../../firebase/clientApp'    
 import {validateFunc} from '../validate'
 
+import {ORDER_STATUS_OPEN, ORDER_STATUS_PROCESSING, ORDER_STATUS_COMPLETE} from "../../../utils/orderStatuses"
+
 
 /*
 * /api/inventory/GetOrdersByStatus
@@ -16,9 +18,6 @@ export const config = {
     }
 };
 
-export const ORDER_STATUS_OPEN = "open";
-export const ORDER_STATUS_PROCESSING = "processing";
-export const ORDER_STATUS_COMPLETE = "complete";
 
 function requireParams(query, res) {
     var {status} = query;
@@ -51,8 +50,7 @@ export default async function(req,res) {
             .then(() => {
                 var ref = firebase.database().ref("/order");                
                 ref.orderByChild("status").equalTo(query["status"]).once("value", snapshot => {
-                    const orders = snapshot.toJSON();
-                    res.status(200).json(orders);
+                    res.status(200).json(snapshot.toJSON());
                     return;
                 })
             })

--- a/pages/api/orders/GetOrdersByStatus.js
+++ b/pages/api/orders/GetOrdersByStatus.js
@@ -1,0 +1,65 @@
+import firebase from '../../../firebase/clientApp'    
+import {validateFunc} from '../validate'
+
+
+/*
+* /api/inventory/GetOrdersByStatus
+* e.x.: /api/inventory/GetOrdersByStatus?status=open
+* request query parameters: status: open, processing, complete
+*/
+
+// something to do with not using the next js body parsing...?
+// may need to disable this in production environments
+export const config = {
+    api: {
+        bodyParser: true,
+    }
+};
+
+export const ORDER_STATUS_OPEN = "open";
+export const ORDER_STATUS_PROCESSING = "processing";
+export const ORDER_STATUS_COMPLETE = "complete";
+
+function requireParams(query, res) {
+    var {status} = query;
+    if (status != ORDER_STATUS_OPEN && status != ORDER_STATUS_PROCESSING && status != ORDER_STATUS_COMPLETE) {
+        res.json({error: "requested status must be either open, processing, or complete"});
+        res.status(400);
+        return false;
+    }
+    return true;
+}
+
+export default async function(req,res) {   
+    // verify this request is legit
+    const token = req.headers.authorization
+    const allowed = await validateFunc(token)
+    if (!allowed) {
+        res.status(401).json({error: "you are not authenticated to perform this action"})
+        return;
+    }
+
+    // verify params
+    const {query} = req;
+    let ok = requireParams(query, res);
+    if (!ok) {
+        return;
+    }
+
+    return new Promise((resolve, reject) => {
+        return firebase.auth().signInAnonymously()
+            .then(() => {
+                var ref = firebase.database().ref("/order");                
+                ref.orderByChild("status").equalTo(ORDER_STATUS_OPEN).once("value", snapshot => {
+                    const orders = snapshot.toJSON();
+                    res.status(200).json(orders);
+                    return;
+                })
+            })
+            .catch(err => {
+                res.status(500);
+                res.json({error: "Error when checking out items: " + err});
+                return;
+            })
+    })
+}

--- a/utils/orderStatuses.js
+++ b/utils/orderStatuses.js
@@ -1,0 +1,3 @@
+export const ORDER_STATUS_OPEN = "open";
+export const ORDER_STATUS_PROCESSING = "processing";
+export const ORDER_STATUS_COMPLETE = "complete";


### PR DESCRIPTION
# Overview
Eventually we'll need to have an orders UI, this should give us the ability to get orders by a new field called `status`. The `status` field isn't in the add order endpoint yet, I'm just assuming we'll add it.

The proposed order status flow is 

- open: an order that has been submitted and has not been worked on yet
- processing: an order that someone is actively working on, maybe through the UI they "claim" an order or something similar
- complete: orders that have been handed off to doordash

I've also added an index on the `status` field in Firebase so that queries against this field will be more efficient.

# Testing
The return object looks like this

<img width="357" alt="Screen Shot 2022-01-23 at 4 21 38 PM" src="https://user-images.githubusercontent.com/16943388/150704380-43e8591a-af96-4969-8bc9-6ff89760147d.png">
