### PR TITLE
handle inventory being zero

### DIFF
--- a/pages/api/inventory/UpdateItem.js
+++ b/pages/api/inventory/UpdateItem.js
@@ -60,7 +60,7 @@ export default async function(req,res) {
     }
 
     FIELDS.forEach(field => {
-      if (body[field]) {
+      if (body[field] || body[field] == 0) {
         updatedFields[field] = body[field];
       }
     });

--- a/pages/api/inventory/UpdateItem.js
+++ b/pages/api/inventory/UpdateItem.js
@@ -60,7 +60,7 @@ export default async function(req,res) {
     }
 
     FIELDS.forEach(field => {
-      if (body[field] || body[field] == 0) {
+      if (body[field] !== undefined) {
         updatedFields[field] = body[field];
       }
     });


### PR DESCRIPTION
If a user enters zero as the quantity body[field] would be false and quantity won't be added to updated fields :( This fix will handle this edge case while also not adding any unnecessary fields to updated fields 