### PR TITLE
add utils markdownStyle.js to tailwind content list

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  content: ['./components/**/*.{js,ts,jsx,tsx}', './pages/**/*.{js,ts,jsx,tsx}'],
+  content: ['./components/**/*.{js,ts,jsx,tsx}', './pages/**/*.{js,ts,jsx,tsx}', './utils/markdownStyle.js'],
   theme: {
     // Extend rather than override theme defaults for now
     extend: {


### PR DESCRIPTION
moved the style formatting for ReactMarkdown to a utils file - added to the list of files that tailwind searches for classes

without this, tailwind doesn't ever know that we want the list-decimal class included (i guess we never use that anywhere else?)