### PR TITLE
fix JSX syntax warning for Head title

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -4,12 +4,13 @@ import Footer from './Footer'
 
 export default function Layout(props) {
   let title = props.pageName
-  if (title) title = String(title) + " | "
+  if (title) title = String(title) + " | Food Pantry"
+  else title = "Food Pantry";
 
   return (
     <>
       <Head>
-        <title>{title}Food Pantry</title>
+        <title>{title}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <div className="h-screen flex flex-col">


### PR DESCRIPTION
fixes this warning

```
Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering
    at title
    at head
    at Head (webpack-internal:///./node_modules/next/dist/pages/_document.js:245:1)
    at html
    at Html (webpack-internal:///./node_modules/next/dist/pages/_document.js:643:106)
    at Document (webpack-internal:///./node_modules/next/dist/pages/_document.js:14:1)
```