### PR TITLE
convert datetime to strings before writing to sheets

### DIFF
--- a/pages/api/inventory/CheckoutItems.js
+++ b/pages/api/inventory/CheckoutItems.js
@@ -78,13 +78,15 @@ function writeLog(log) {
       let now = new Date();
 
       let input = []
-      let row1 = now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }).replace(',', '')
+      let date = now.toLocaleDateString('en-US', { weekday: 'long', month: 'numeric', day: 'numeric' });
+      let time = now.toLocaleTimeString('en-US', { hour12: false, hour: "numeric", minute: "numeric" });
 
       // create payload to write to sheet. only first row of checkout should have timestamp
       for (let barcode in log) {
         let itemLog = log[barcode]
-        input.push([row1, row1, barcode, itemLog.quantity, itemLog.itemName, itemLog.newQuantity])
-        row1 = "";
+        input.push([date, time, barcode, itemLog.quantity, itemLog.itemName, itemLog.newQuantity])
+        date = "";
+        time = "";
       }
 
       const values = {
@@ -112,9 +114,7 @@ function writeLog(log) {
           spreadsheetId: spreadsheetId,
           resource: {
             requests: [
-              requestFormat(0, { type: "DATE", pattern: "ddddd m/dd" }), // column 1 (date)
-              requestFormat(1, { type: "TIME", pattern: "h:mm am/pm" }), // column 2 (time)
-              requestFormat(2, { type: "TEXT" }),                        // column 3 (barcode)
+              requestFormat([0, 3], { type: "TEXT" }),                   // column 1-3 (date, time, barcode)
               requestFormat([3, 6]),                                     // column 4-6 (quantity, name, new quantity)
             ]
           }

--- a/pages/api/inventory/CheckoutItems.js
+++ b/pages/api/inventory/CheckoutItems.js
@@ -83,11 +83,11 @@ function writeLog(log) {
 
       // create payload to write to sheet. only first row of checkout should have timestamp
       for (let barcode in log) {
+        let itemLog = log[barcode]
         if (itemLog.quantity <= 0){
           continue;
         }
 
-        let itemLog = log[barcode]
         input.push([date, time, barcode, itemLog.quantity, itemLog.itemName, itemLog.newQuantity])
         date = "";
         time = "";

--- a/pages/api/inventory/CheckoutItems.js
+++ b/pages/api/inventory/CheckoutItems.js
@@ -118,8 +118,8 @@ function writeLog(log) {
           spreadsheetId: spreadsheetId,
           resource: {
             requests: [
-              // requestFormat([0, 3], { type: "TEXT" }),                   // column 1-3 (date, time, barcode)
-              requestFormat([0, 6]),                                     // column 4-6 (quantity, name, new quantity)
+              requestFormat([0, 3], { type: "TEXT" }),                   // column 1-3 (date, time, barcode)
+              requestFormat([3, 6]),                                     // column 4-6 (quantity, name, new quantity)
             ]
           }
         }

--- a/pages/api/inventory/CheckoutItems.js
+++ b/pages/api/inventory/CheckoutItems.js
@@ -78,7 +78,7 @@ function writeLog(log) {
       let now = new Date();
 
       let input = []
-      let date = now.toLocaleDateString('en-US', { weekday: 'long', month: 'numeric', day: 'numeric' });
+      let date = now.toLocaleDateString('en-US', { weekday: 'long', month: 'numeric', day: 'numeric' }).replace(',', '');
       let time = now.toLocaleTimeString('en-US', { hour12: false, hour: "numeric", minute: "numeric" });
 
       // create payload to write to sheet. only first row of checkout should have timestamp
@@ -114,8 +114,8 @@ function writeLog(log) {
           spreadsheetId: spreadsheetId,
           resource: {
             requests: [
-              requestFormat([0, 3], { type: "TEXT" }),                   // column 1-3 (date, time, barcode)
-              requestFormat([3, 6]),                                     // column 4-6 (quantity, name, new quantity)
+              // requestFormat([0, 3], { type: "TEXT" }),                   // column 1-3 (date, time, barcode)
+              requestFormat([0, 6]),                                     // column 4-6 (quantity, name, new quantity)
             ]
           }
         }


### PR DESCRIPTION
deals with the concurrency issue when we fail to reformat the date/time columns if two checkouts occur at the exact same time. does the reformatting on our side so we don't need the sheets API to do the reformatting