### PR TITLE
Move auth verification to vercel, store state in user context instead of cookies

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -2,7 +2,6 @@ import { useRouter } from "next/router";
 import { useUser } from '../context/userContext'
 import { useState } from 'react'
 import { server } from '../pages/_app.js'
-import cookie from 'js-cookie';
 
 const DISABLE_PUBLIC_INVENTORY = true;
 
@@ -42,7 +41,7 @@ export default function Navbar() {
   const activeLink = `${linkStyle} text-white`;
   const inactiveLink = `${linkStyle} text-gray-300 hover:text-white`;
   const router = useRouter();
-  const { loadingUser, user } = useUser()
+  const { user } = useUser()
   
   const [showUserInfo, setShowUserInfo] = useState(false)
   const [showTabs, setShowTabs] = useState(false)
@@ -54,7 +53,6 @@ export default function Navbar() {
 
   // if they're signed in 
   if (user) {
-    console.log("User Data:", user)
     name = user.displayName;
     routes = UNAUTH_SIGNEDIN_ROUTES
     // if they're an admin

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -41,7 +41,7 @@ export default function Navbar() {
   const activeLink = `${linkStyle} text-white`;
   const inactiveLink = `${linkStyle} text-gray-300 hover:text-white`;
   const router = useRouter();
-  const { user } = useUser()
+  const { user, loadingUser } = useUser()
   
   const [showUserInfo, setShowUserInfo] = useState(false)
   const [showTabs, setShowTabs] = useState(false)
@@ -94,7 +94,9 @@ export default function Navbar() {
 
       {/* User Info */}
       <div className='flex-grow mr-3 xl:order-2 xl:flex-grow-0'>
-        {!user ? <a className="bg-gray-50 text-gray-600 rounded px-3 py-1 float-right" href="/signin">Sign In</a> :
+        {!user ?
+          !loadingUser && <a className="bg-gray-50 text-gray-600 rounded px-3 py-1 float-right" href="/signin">Sign In</a>
+          :
           <div className="flex flex-col float-right">
             {/* circle with user initials */}
             <button className="focus:outline-none w-8 h-8 rounded-full bg-gray-50 text-gray-600 font-semibold truncate" onClick={toggleUserDropdown}>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -36,8 +36,6 @@ const AUTH_SIGNEDIN_ROUTES = [
   { title: "Bag Packing", route: "/orders"}
 ]
 
-const token = cookie.get("firebaseToken")
-
 export default function Navbar() {
   const linkStyle = "w-full relative inline-block py-2 pr-3 pl-3 text-white rounded hover:bg-pantry-blue-400 " +
     "xl:ml-4 xl:px-3 xl:py-2 xl:text-sm xl:font-medium xl:hover:bg-pantry-blue-500"
@@ -56,17 +54,18 @@ export default function Navbar() {
 
   // if they're signed in 
   if (user) {
+    console.log("User Data:", user)
     name = user.displayName;
     routes = UNAUTH_SIGNEDIN_ROUTES
     // if they're an admin
-    if (user.authorized === "true") {
+    if (user.authorized) {
       routes = AUTH_SIGNEDIN_ROUTES;
       userType = "Administrator";
 
       // update numNewOrders
       if (numNewOrders === false) {
         fetch(`${server}/api/orders/GetOrdersByStatus?status=open`, { method: 'GET',
-          headers: {'Content-Type': "application/json", 'Authorization': token}
+          headers: {'Content-Type': "application/json", 'Authorization': user.authToken}
         })
         .then(resp => resp.json())
         .then(newOrders => {

--- a/context/userContext.js
+++ b/context/userContext.js
@@ -6,6 +6,7 @@ export const UserContext = createContext()
 
 const UserProvider = ({ children }) => {
   const [user, setUser] = useState(null)
+  const [loadingUser, setLoading] = useState(true)
   // Google identity prvider.
   const googleLogin = async () => {
     var provider = new firebase.auth.GoogleAuthProvider();
@@ -50,6 +51,7 @@ const UserProvider = ({ children }) => {
   // note that the user here is different from the user retrieved from useState, this one is from Google
   // the useState user is updated with setUser
   const onAuthStateChange = () => {
+    setLoading(true);
     return firebase.auth().onAuthStateChanged(async (userAuth) => {
       if (userAuth) {
         authorizeLogin(userAuth.email).then((isAuthorized) => {
@@ -63,6 +65,7 @@ const UserProvider = ({ children }) => {
                 "googleUser": userAuth,
                 "authToken": tok
               });
+              setLoading(false);
             });
           } else {
             setUser({
@@ -71,10 +74,12 @@ const UserProvider = ({ children }) => {
               "authorized": false,
               "googleUser": userAuth
             });
+            setLoading(false);
           }
         })
       } else {
         console.log("No user found.");
+        setLoading(false);
       }
     });
   };
@@ -86,7 +91,7 @@ const UserProvider = ({ children }) => {
     };
   }, []);
 
-  return <UserContext.Provider value={{ user, setUser, googleLogin, logout }}>{children}</UserContext.Provider>;
+  return <UserContext.Provider value={{ user, setUser, googleLogin, logout, loadingUser }}>{children}</UserContext.Provider>;
 };
 
 export default UserProvider;

--- a/context/userContext.js
+++ b/context/userContext.js
@@ -47,9 +47,7 @@ const UserProvider = ({ children }) => {
     })
   }
 
-  // Checks that user state has changed and then creates or destroys cookie with Firebase token.
-  // note that the user here is different from the user retrieved from useState, this one is from Google
-  // the useState user is updated with setUser
+  // updates user state variable when authorization state changes (i.e. someone logs in with google)
   const onAuthStateChange = () => {
     setLoading(true);
     return firebase.auth().onAuthStateChanged(async (userAuth) => {
@@ -60,7 +58,6 @@ const UserProvider = ({ children }) => {
             userAuth.getIdToken().then((tok) => {
               setUser({
                 "displayName": userAuth.displayName,
-                "photoURL": userAuth.photoURL,
                 "authorized": isAuthorized,
                 "googleUser": userAuth,
                 "authToken": tok

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,26 +19,26 @@ export default function MyApp({ Component, pageProps }) {
 
 // this stuff puts stuff into props...do we need to do that if everything is stored in the context?
 // when you remove this there are some issues with making CORS requests...why?
-MyApp.getInitialProps = async (appContext) => {
-  const { ctx } = appContext;
-  // Calls `getInitialProps` and fills `appProps.pageProps`
-  let error;
-  const appProps = await App.getInitialProps(appContext);
+// MyApp.getInitialProps = async (appContext) => {
+//   const { ctx } = appContext;
+//   // Calls `getInitialProps` and fills `appProps.pageProps`
+//   let error;
+//   const appProps = await App.getInitialProps(appContext);
 
-  const { firebaseToken } = cookies(ctx);
+//   const { firebaseToken } = cookies(ctx);
 
-  // If token exists run Firebase validation on server side before rendering.
-  if (firebaseToken) {
-    try {
-      const headers = {
-        'Context-Type': 'application/json',
-        Authorization: JSON.stringify({ "token": firebaseToken }),
-      };
-      const result = await fetch(`${server}/api/validate`, { headers }).then((res) => res.json());
-      return { ...result, ...appProps };
-    } catch (e) {
-      console.log(e);
-    }
-  }
-  return { ...appProps };
-};
+//   // If token exists run Firebase validation on server side before rendering.
+//   if (firebaseToken) {
+//     try {
+//       const headers = {
+//         'Context-Type': 'application/json',
+//         Authorization: JSON.stringify({ "token": firebaseToken }),
+//       };
+//       const result = await fetch(`${server}/api/validate`, { headers }).then((res) => res.json());
+//       return { ...result, ...appProps };
+//     } catch (e) {
+//       console.log(e);
+//     }
+//   }
+//   return { ...appProps };
+// };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -17,8 +17,9 @@ export default function MyApp({ Component, pageProps }) {
   )
 }
 
-// this stuff puts stuff into props...do we need to do that if everything is stored in the context?
-// when you remove this there are some issues with making CORS requests...why?
+// this code apparently prevents issues with making CORS requests (...why?)
+// we've disabled it for now because it has been causing errors in the API
+
 // MyApp.getInitialProps = async (appContext) => {
 //   const { ctx } = appContext;
 //   // Calls `getInitialProps` and fills `appProps.pageProps`

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -388,8 +388,17 @@ function DeliveryTimes(props) {
 }
 
 export default function Admin() {
-  const { user } = useUser();
+  const { user, loadingUser } = useUser();
+
   let authToken = (user && user.authorized) ? user.authToken : null;
+
+  if (loadingUser) {
+    return (
+      <Layout pageName="Checkout">
+          <h1 className='text-xl m-6'>Loading...</h1>
+      </Layout>
+    )
+  }
 
   if (!authToken) {
     return (

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,6 +1,5 @@
 import Layout from '../components/Layout'
 import useSWR from 'swr'
-import cookie from 'js-cookie';
 
 import { useState } from 'react'
 import { useUser } from '../context/userContext'
@@ -388,8 +387,7 @@ function DeliveryTimes(props) {
 
 export default function Admin() {
   const { user } = useUser();
-  const token = cookie.get("firebaseToken");
-  let authToken = (user && user.authorized === "true") ? token : null;
+  let authToken = (user && user.authorized) ? user.authToken : null;
 
   if (!authToken) {
     return (

--- a/pages/api/inventory/ResetInventory.js
+++ b/pages/api/inventory/ResetInventory.js
@@ -53,11 +53,18 @@ export default async function (req, res) {
               })
               .catch((error) => {
                 res.status(500);
-                res.json({ message: "Error updating firebase inventory:" });
+                res.json({ message: "Error updating firebase inventory" });
                 return resolve("Error updating firebase inventory: " + error);
               });
+          }).catch((error) => {
+            res.status(500);
+            res.json({ message: "Error fetching inventory" });
+            return resolve("Error fetching inventory: " + error);
           })
         );
+    }).catch(() => {
+      res.status(401).json({ error: "You are not authorized to perform this action. Make sure you are logged in to an administrator account." })
+      return resolve();
     });
   });
 }

--- a/pages/api/orders/GetOrder/[id].js
+++ b/pages/api/orders/GetOrder/[id].js
@@ -23,7 +23,6 @@ export default async function (req, res) {
       query: { id },
     } = req;
 
-    console.log("ID:", typeof(id))
     if (id === undefined || id === "") {
       res.status(400).json({ error: "missing order ID" });
       return resolve();
@@ -37,6 +36,7 @@ export default async function (req, res) {
         .then(function (resp) {
           // the version of the order in the database
           var dbItem = resp.val();
+
           // this order was not found
           if (dbItem === null) {
             res.status(404);

--- a/pages/api/orders/GetOrder/[id].js
+++ b/pages/api/orders/GetOrder/[id].js
@@ -23,6 +23,12 @@ export default async function (req, res) {
       query: { id },
     } = req;
 
+    console.log("ID:", typeof(id))
+    if (id === undefined || id === "") {
+      res.status(400).json({ error: "missing order ID" });
+      return resolve();
+    }
+
     validateFunc(token).then(() => {
       firebase.auth().signInAnonymously()
       .then(() => {

--- a/pages/api/validate.js
+++ b/pages/api/validate.js
@@ -32,7 +32,7 @@ export const validateFunc = async (token) => {
   })
 };
 
-export default async (req, res) => {
+export default (req, res) => {
   // Check if there is a token and if not return undefined.
   const { token } = JSON.parse(req.headers.authorization || '{}');
 

--- a/pages/api/validate.js
+++ b/pages/api/validate.js
@@ -1,57 +1,54 @@
 import admin from '../../utils/auth/firebaseAdmin'    
 
 export const validateFunc = async (token) => {
-  
   return new Promise((resolve, reject) => {
     // apparently getting headers that don't exist return "undefined" the string ¯\_(ツ)_/¯
     if (token === "undefined" || typeof token === "undefined") {
-      reject("No token provided")
-      return false
+      return reject("No token provided")
     }
     // get list of authorized users
-    admin.database().ref('/authorizedUser') 
+    admin.database().ref('/authorizedUser')
     .once('value', snapshot => {
       // check if the token is valid
       return admin.auth().verifyIdToken(token, true)
-      .catch(error => {
-        reject(error)
-        return false
-      })
       .then(decoded => {
         // the ID token is valid
         // now check if the user pulled from the token is authorized
         var vals = snapshot.val()
         for (const key in vals) {
           if (vals[key] === decoded.email && decoded.email_verified) {
-            resolve(true)
+            return resolve(true)
           }
         }
-        reject("Valid token but unallowed email")
-      })      
+        return reject("Valid token but unallowed email")
+      })
+      .catch(error => {
+        return reject(error)
+      })
+    })
+    .catch(error => {
+      return reject(error)
     });
   })
 };
 
-export default async (req, res) => {
+export default (req, res) => {
   // Check if there is a token and if not return undefined.
-  
   const { token } = JSON.parse(req.headers.authorization || '{}');
+
   if (!token) {
     return res.status(403).json({
       message: 'Auth token missing.'
     });
   }
+
   // Call the validate function above that gets the user data
   // this data ends up getting passed to every page's props
-  validateFunc(token).then(() => {
-    const result = {
-      "user": {
-        "Data": "Hello"
-      },
-    };
-    return res.status(200).json(result);
-  }).catch(err => {
-    console.log(err)
-    return res.status(403).json({message: "No user found."});
+  return validateFunc(token)
+  .then(() => {
+    return res.status(200).json({message: "Success!"});
+  })
+  .catch(err => {
+    return res.status(403).json({message: "No user found.", error: err});
   })
 };

--- a/pages/api/validate.js
+++ b/pages/api/validate.js
@@ -33,29 +33,25 @@ export const validateFunc = async (token) => {
 };
 
 export default async (req, res) => {
-  try {
-    // Check if there is a token and if not return undefined.
-    
-    const { token } = JSON.parse(req.headers.authorization || '{}');
-    if (!token) {
-      return res.status(403).send({
-        errorCode: 403,
-        message: 'Auth token missing.',
-      });
-    }
-    // Call the validate function above that gets the user data
-    // this data ends up getting passed to every page's props
-    const authenticated = await validateFunc(token);
+  // Check if there is a token and if not return undefined.
+  
+  const { token } = JSON.parse(req.headers.authorization || '{}');
+  if (!token) {
+    return res.status(403).json({
+      message: 'Auth token missing.'
+    });
+  }
+  // Call the validate function above that gets the user data
+  // this data ends up getting passed to every page's props
+  validateFunc(token).then(() => {
     const result = {
       "user": {
         "Data": "Hello"
       },
     };
-    return res.status(200).send(JSON.stringify(result));
-  } catch (err) {
-    // Return undefined if there is no user. You may also send a different status or handle the error in any way that you wish.
-    console.log(err);
-    const result = undefined;
-    return res.status(200).send(result);
-  }
+    return res.status(200).json(result);
+  }).catch(err => {
+    console.log(err)
+    return res.status(403).json({message: "No user found."});
+  })
 };

--- a/pages/api/validate.js
+++ b/pages/api/validate.js
@@ -32,7 +32,7 @@ export const validateFunc = async (token) => {
   })
 };
 
-export default (req, res) => {
+export default async (req, res) => {
   // Check if there is a token and if not return undefined.
   const { token } = JSON.parse(req.headers.authorization || '{}');
 

--- a/pages/checkin.js
+++ b/pages/checkin.js
@@ -1,6 +1,5 @@
 import Layout from '../components/Layout'
 import { useEffect, useState } from 'react'
-import cookie from 'js-cookie';
 import React from 'react';
 
 import { useUser } from '../context/userContext'
@@ -8,13 +7,12 @@ import { server } from './_app.js'
 
 const fetcher = (url) => fetch(url).then((res) => res.json())
 
-var token = cookie.get("firebaseToken")
 
 class Checkin extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      user:props.user,
+      user: props.user,
       error: null,
       success: null,
       lastScannedID: "N/A",
@@ -119,7 +117,7 @@ class Checkin extends React.Component {
   writeIDtoSheet = async (id) => {
     fetch('/api/admin/WriteCheckIn', { method: 'POST',
     body: JSON.stringify({calID: id, isGrad:false}),
-    headers: {'Content-Type': "application/json", 'Authorization': token}
+    headers: {'Content-Type': "application/json", 'Authorization': this.state.user.authToken}
     })
     .then(() => {
       this.showSuccess("Sucessfully logged ID: " + id,1000)
@@ -134,10 +132,9 @@ class Checkin extends React.Component {
       this.showError("Can't submit blank ID: " + e.target.calID.value,1000)
       return
     }
-    token = await this.state.user.googleUser.getIdToken()
     fetch('/api/admin/CheckPreviousVisit', { method: 'POST',
       body: JSON.stringify({calID: e.target.calID.value, isGrad:false}),
-      headers: {'Content-Type': "application/json", 'Authorization': token}
+      headers: {'Content-Type': "application/json", 'Authorization': this.state.user.authToken}
     })
     .then((result) => {
       result.json()
@@ -218,7 +215,7 @@ class Checkin extends React.Component {
 export default function checkin() {
   /* Display loading message */
   const { user } = useUser();
-  let authToken = (user && user.authorized === "true") ? token : null;
+  let authToken = (user && user.authorized) ? user.authToken : null;
   if (!authToken) {
     return (
       <Layout pageName="Check-In">

--- a/pages/checkin.js
+++ b/pages/checkin.js
@@ -213,8 +213,17 @@ class Checkin extends React.Component {
 
 
 export default function checkin() {
+  const { user, loadingUser } = useUser();
+
   /* Display loading message */
-  const { user } = useUser();
+  if (loadingUser) {
+    return (
+      <Layout pageName="Checkout">
+        <h1 className='text-xl m-6'>Loading...</h1>
+      </Layout>
+    )
+  }
+
   let authToken = (user && user.authorized) ? user.authToken : null;
   if (!authToken) {
     return (

--- a/pages/checkinGrad.js
+++ b/pages/checkinGrad.js
@@ -1,5 +1,4 @@
 import Layout from '../components/Layout'
-import cookie from 'js-cookie';
 import React from 'react';
 
 import { useUser } from '../context/userContext'
@@ -7,7 +6,6 @@ import { server } from './_app.js'
 
 const fetcher = (url) => fetch(url).then((res) => res.json())
 
-var token = cookie.get("firebaseToken")
 
 class Checkin extends React.Component {
   constructor(props) {
@@ -118,7 +116,7 @@ class Checkin extends React.Component {
   writeIDtoSheet = async (id) => {
     fetch('/api/admin/WriteCheckIn', { method: 'POST',
     body: JSON.stringify({calID: id, isGrad:true}),
-    headers: {'Content-Type': "application/json", 'Authorization': token}
+    headers: {'Content-Type': "application/json", 'Authorization': this.state.user.authToken}
     })
     .then(() => {
       this.showSuccess("Sucessfully logged ID: " + id,1000)
@@ -133,10 +131,9 @@ class Checkin extends React.Component {
       this.showError("Can't submit blank ID: " + e.target.calID.value,1000)
       return
     }
-    token = await this.state.user.googleUser.getIdToken()
     fetch('/api/admin/CheckPreviousVisit', { method: 'POST',
       body: JSON.stringify({calID: e.target.calID.value, isGrad:true}),
-      headers: {'Content-Type': "application/json", 'Authorization': token}
+      headers: {'Content-Type': "application/json", 'Authorization': this.state.user.authToken}
     })
     .then((result) => {
       result.json()
@@ -217,7 +214,7 @@ class Checkin extends React.Component {
 export default function checkinGrad() {
   /* Display loading message */
   const { user } = useUser();
-  let authToken = (user && user.authorized === "true") ? token : null;
+  let authToken = (user && user.authorized) ? user.authToken : null;
   if (!authToken) {
     return (
       <Layout pageName="Grad Check-In">

--- a/pages/checkinGrad.js
+++ b/pages/checkinGrad.js
@@ -212,13 +212,22 @@ class Checkin extends React.Component {
 
 
 export default function checkinGrad() {
+  const { user, loadingUser } = useUser();
+
   /* Display loading message */
-  const { user } = useUser();
+  if (loadingUser) {
+    return (
+      <Layout pageName="Checkout">
+        <h1 className='text-xl m-6'>Loading...</h1>
+      </Layout>
+    )
+  }
+
   let authToken = (user && user.authorized) ? user.authToken : null;
   if (!authToken) {
     return (
       <Layout pageName="Grad Check-In">
-          <h1 className='text-xl m-6'>Sorry, you are not authorized to view this page.</h1>
+        <h1 className='text-xl m-6'>Sorry, you are not authorized to view this page.</h1>
       </Layout>
     )
   }

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -25,9 +25,9 @@ function fetcher(...urls) {
 class Cart extends React.Component {
   constructor(props) {
     super(props);
+    this.user = props.user;
     this.data = props.data[1];
     this.state = {
-      user: props.data.user,
       items: new Map([]),   /* entries are {barcode: [itemStruct, quantity]} */
       itemsInCart: 0,
       error: null,
@@ -234,7 +234,7 @@ class Cart extends React.Component {
 
   submitCart = async (e) => {
     e.preventDefault();
-    let token = await this.state.user.googleUser.getIdToken()
+    let token = await this.user.googleUser.getIdToken()
 
     let reqbody = this.makeReq();
     this.showSuccess("Submitting cart...", 10000)
@@ -480,7 +480,7 @@ class Cart extends React.Component {
             {/* save edit */}
             {this.state.isEditing && <button className='ml-5 text-blue-700 hover:text-blue-500'
                 onClick={async () => {
-                let token = await this.state.user.googleUser.getIdToken()
+                let token = await this.user.googleUser.getIdToken()
                 this.setState({isEditing:false});
                 fetch('/api/admin/SetCheckoutInfo', { method: 'POST',
                   body: JSON.stringify({markdown: this.state.checkoutInfo}),
@@ -542,7 +542,6 @@ export default function Checkout() {
       </Layout>
     )
   } else {
-    data["user"] = user
-    return (<Cart data={data}></Cart>)
+    return (<Cart data={data} user={user}></Cart>)
   }
 }

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -235,6 +235,7 @@ class Cart extends React.Component {
   submitCart = async (e) => {
     e.preventDefault();
     this.setState({loading: true})
+    let token = this.user.googleUser.getIdToken()
 
     let reqbody = this.makeReq();
     this.showSuccess("Submitting cart...", 10000)
@@ -246,7 +247,7 @@ class Cart extends React.Component {
     
     fetch('/api/inventory/CheckoutItems', { method: 'POST',
       body: reqbody,
-      headers: {'Content-Type': "application/json", 'Authorization': this.user.authToken}
+      headers: {'Content-Type': "application/json", 'Authorization': token}
     })
     .then(resp => {
       if (resp.ok) {
@@ -482,10 +483,11 @@ class Cart extends React.Component {
             {/* save edit */}
             {this.state.isEditing && <button className='ml-5 text-blue-700 hover:text-blue-500'
                 onClick={async () => {
+                let token = await this.user.googleUser.getIdToken()
                 this.setState({isEditing:false});
                 fetch('/api/admin/SetCheckoutInfo', { method: 'POST',
                   body: JSON.stringify({markdown: this.state.checkoutInfo}),
-                  headers: {'Content-Type': "application/json", 'Authorization': this.user.authToken}
+                  headers: {'Content-Type': "application/json", 'Authorization': token}
                 }).then((res) => {
                 })
               }}>

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -25,9 +25,9 @@ function fetcher(...urls) {
 class Cart extends React.Component {
   constructor(props) {
     super(props);
-    this.user = props.user;
     this.data = props.data[1];
     this.state = {
+      user: props.data.user,
       items: new Map([]),   /* entries are {barcode: [itemStruct, quantity]} */
       itemsInCart: 0,
       error: null,
@@ -234,7 +234,7 @@ class Cart extends React.Component {
 
   submitCart = async (e) => {
     e.preventDefault();
-    let token = await this.user.googleUser.getIdToken()
+    let token = await this.state.user.googleUser.getIdToken()
 
     let reqbody = this.makeReq();
     this.showSuccess("Submitting cart...", 10000)
@@ -480,7 +480,7 @@ class Cart extends React.Component {
             {/* save edit */}
             {this.state.isEditing && <button className='ml-5 text-blue-700 hover:text-blue-500'
                 onClick={async () => {
-                let token = await this.user.googleUser.getIdToken()
+                let token = await this.state.user.googleUser.getIdToken()
                 this.setState({isEditing:false});
                 fetch('/api/admin/SetCheckoutInfo', { method: 'POST',
                   body: JSON.stringify({markdown: this.state.checkoutInfo}),
@@ -542,6 +542,7 @@ export default function Checkout() {
       </Layout>
     )
   } else {
-    return (<Cart data={data} user={user}></Cart>)
+    data["user"] = user
+    return (<Cart data={data}></Cart>)
   }
 }

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -235,7 +235,6 @@ class Cart extends React.Component {
   submitCart = async (e) => {
     e.preventDefault();
     this.setState({loading: true})
-    let token = await this.user.googleUser.getIdToken()
 
     let reqbody = this.makeReq();
     this.showSuccess("Submitting cart...", 10000)
@@ -247,7 +246,7 @@ class Cart extends React.Component {
     
     fetch('/api/inventory/CheckoutItems', { method: 'POST',
       body: reqbody,
-      headers: {'Content-Type': "application/json", 'Authorization': token}
+      headers: {'Content-Type': "application/json", 'Authorization': this.user.authToken}
     })
     .then(resp => {
       if (resp.ok) {
@@ -483,11 +482,10 @@ class Cart extends React.Component {
             {/* save edit */}
             {this.state.isEditing && <button className='ml-5 text-blue-700 hover:text-blue-500'
                 onClick={async () => {
-                let token = await this.user.googleUser.getIdToken()
                 this.setState({isEditing:false});
                 fetch('/api/admin/SetCheckoutInfo', { method: 'POST',
                   body: JSON.stringify({markdown: this.state.checkoutInfo}),
-                  headers: {'Content-Type': "application/json", 'Authorization': token}
+                  headers: {'Content-Type': "application/json", 'Authorization': this.user.authToken}
                 }).then((res) => {
                 })
               }}>

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -525,8 +525,16 @@ export default function Checkout() {
     ["/api/admin/GetCheckoutInfo", "/api/inventory/GetAllItems"],
     fetcher
   );
-  const { user } = useUser();
+  const { user, loadingUser } = useUser();
 
+  if (loadingUser) {
+    return (
+      <Layout pageName="Checkout">
+          <h1 className='text-xl m-6'>Loading...</h1>
+      </Layout>
+    )
+  }
+  
   if (!data || !user) {
     return (
       <Layout pageName="Checkout">

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -545,6 +545,12 @@ export default function Checkout() {
       </Layout>
     )
   } else {
+    data["defaultCart"] = []
+    for (let item in data[1]) {
+      if (data[1][item]["defaultCart"]) {
+        data["defaultCart"].push(data[1][item]["barcode"])
+      }
+    }
     return (<Cart data={data} user={user}></Cart>)
   }
 }

--- a/pages/hours.js
+++ b/pages/hours.js
@@ -1,13 +1,10 @@
 import Layout from '../components/Layout'
-import { useEffect, useState } from 'react'
-import cookie from 'js-cookie';
+import { useState } from 'react'
 
 import { useUser } from '../context/userContext'
 import { server } from './_app.js'
 
 export const daysInOrder = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
-
-const token = cookie.get("firebaseToken")
 
 export default function Hours() {
 
@@ -46,7 +43,7 @@ export default function Hours() {
     )
   }
 
-  let authToken = (user && user.authorized === "true") ? token : null;
+  let authToken = (user && user.authorized) ? user.authToken : null;
 
   let saveHours = (day, event) => {
     event.preventDefault();
@@ -58,7 +55,7 @@ export default function Hours() {
           "day": day,
           "hours": hourString,
       }),
-      headers: { 'Content-Type': "application/json", 'Authorization': token }
+      headers: { 'Content-Type': "application/json", 'Authorization': authToken }
     })
     .then(response => {
       if (response.ok) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,15 +5,12 @@ import { server } from './_app.js'
 import { useState } from "react";
 import ReactMarkdown from 'react-markdown';
 import { markdownStyle } from "../utils/markdownStyle";
-import cookie from "js-cookie";
 
 export default function Home() {
   // Our custom hook to get context values
   const { user } = useUser();
-  const token = cookie.get("firebaseToken");
 
-  console.log("User:", user);
-  let authToken = (user && user.authorized === "true") ? token : null;
+  let authToken = (user && user.authorized) ? user.authToken : null;
 
   const [info, setInfo] = useState(false);
   const [isEditingInfo, setIsEditingInfo] = useState(false);
@@ -55,7 +52,7 @@ export default function Home() {
             setIsEditingInfo(false);
             fetch('/api/admin/SetHomeInfo', { method: 'POST',
               body: JSON.stringify({markdown: info}),
-              headers: {'Content-Type': "application/json", 'Authorization': token}
+              headers: {'Content-Type': "application/json", 'Authorization': authToken}
             }).then((res) => {
               if (!res.ok) {
                 res.json().then(err => console.log("SetHomeInfo error: " + err.error))

--- a/pages/inventory.js
+++ b/pages/inventory.js
@@ -8,14 +8,14 @@ import { server } from './_app.js'
 
 import Modal from 'react-modal'
 import React, { useState, useReducer } from 'react';
-import cookie from 'js-cookie';
 import firebase from '../firebase/clientApp';
 
 /* For hiding inventory to the public */
 const DISABLE_PUBLIC_INVENTORY = true;
 
 export default function Inventory() {
-  const token = cookie.get("firebaseToken")
+  const { user } = useUser();
+  let authToken = (user && user.authorized) ? user.authToken : null;
 
   const emptyItem =  {
     itemName: "",
@@ -182,7 +182,7 @@ export default function Inventory() {
 
     fetch(`${server}/api/inventory/UpdateItem`, { method: 'POST',
       body: payload,
-      headers: {'Content-Type': "application/json", 'Authorization': token}})
+      headers: {'Content-Type': "application/json", 'Authorization': authToken}})
     .then((response) => response.json())
     .then(json => {
       if (json.error) {
@@ -195,7 +195,7 @@ export default function Inventory() {
     if (confirm(`Deleting item with barcode ${barcode}. Are you sure?`)){
       fetch(`${server}/api/inventory/DeleteItem`, { method: 'POST',
         body: JSON.stringify({barcode: barcode}),
-        headers: {'Content-Type': "application/json", 'Authorization': token}})
+        headers: {'Content-Type': "application/json", 'Authorization': authToken}})
       .then(() => {
         // remove something from dataState
         let { [barcode]: deletedItem, ...newDataState } = dataState
@@ -284,7 +284,7 @@ export default function Inventory() {
     
     fetch(`${server}/api/inventory/UpdateItem`, { method: 'POST',
       body: payload,
-      headers: {'Content-Type': "application/json", 'Authorization': token}})
+      headers: {'Content-Type': "application/json", 'Authorization': authToken}})
     .then((response) => response.json())
     .then(json => {
       if (json.error) {
@@ -309,7 +309,7 @@ export default function Inventory() {
   function resetInventory() {
     if (window.confirm("Reset Inventory?")) {
     fetch(`${server}/api/inventory/ResetInventory`, { method: 'POST',
-      headers: {'Content-Type': "application/json", 'Authorization': token}})
+      headers: {'Content-Type': "application/json", 'Authorization': authToken}})
     .then((response) => response.json())
     .then(json => {
       if (json.error) {
@@ -359,7 +359,7 @@ export default function Inventory() {
 
     fetch(`${server}/api/inventory/AddItem`, { method: 'POST', 
       body: JSON.stringify(payload),
-      headers: {'Content-Type': "application/json", 'Authorization': token}})
+      headers: {'Content-Type': "application/json", 'Authorization': authToken}})
     .then((response) => {
       if (response.status == 500) {
         setStatusError("Internal server error (make sure you're logged in)");
@@ -419,9 +419,6 @@ export default function Inventory() {
       ...status, loading: false, error: ""
     })
   }
-
-  const { loadingUser, user } = useUser();
-  let authToken = (user && user.authorized === "true") ? token : null;
 
   if (DISABLE_PUBLIC_INVENTORY && !authToken) {
     return (

--- a/pages/inventory.js
+++ b/pages/inventory.js
@@ -14,7 +14,8 @@ import firebase from '../firebase/clientApp';
 const DISABLE_PUBLIC_INVENTORY = true;
 
 export default function Inventory() {
-  const { user } = useUser();
+  const { user, loadingUser } = useUser();
+
   let authToken = (user && user.authorized) ? user.authToken : null;
 
   const emptyItem =  {
@@ -433,10 +434,18 @@ export default function Inventory() {
     })
   }
 
+  if (loadingUser) {
+    return (
+      <Layout pageName="Inventory">
+          <h1 className='text-xl m-6'>Loading...</h1>
+      </Layout>
+    )
+  }
+
   if (DISABLE_PUBLIC_INVENTORY && !authToken) {
     return (
       <Layout pageName="Inventory">
-        <div className='m-4'>Inventory is currently not publically available.</div>
+        <div className='text-xl m-6'>Inventory is currently not publically available.</div>
       </Layout>
     )
   }

--- a/pages/inventory.js
+++ b/pages/inventory.js
@@ -431,7 +431,7 @@ export default function Inventory() {
   return (
     <>
       <Layout pageName="Inventory">
-        {!authToken ? "" :
+        { authToken &&
           <>
             {/* Add Item Modal */}
             <Modal id="add-item-modal" isOpen={showAddItem} onRequestClose={closeAddItem} ariaHideApp={false}>
@@ -490,7 +490,7 @@ export default function Inventory() {
         }
         
         <div className="flex">
-          {!(user && user.authorized === "true") ? "" :
+          {!(user && authToken) ? "" :
               <div className="w-64 items-center">
                 <Sidebar>
                   <h1 className="text-3xl font-semibold mb-2">Inventory</h1>

--- a/pages/order.js
+++ b/pages/order.js
@@ -11,7 +11,6 @@ import { server } from './_app.js'
 import { useState, useContext } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { markdownStyle } from '../utils/markdownStyle';
-import cookie from 'js-cookie';
 
 export default function Order() {
   let { cart, personal, delivery } = useContext(StateCartContext)
@@ -167,8 +166,7 @@ export default function Order() {
   }
 
   const { user } = useUser();
-  const token = cookie.get("firebaseToken")
-  let authToken = (user && user.authorized === "true") ? token : null;
+  let authToken = (user && user.authorized) ? user.authToken : null;
 
   let infoDiv = <div className='py-8 px-16 xl:w-1/2 max-w-2xl rounded'>
     {/* Editing the information */}
@@ -192,7 +190,7 @@ export default function Order() {
         setIsEditingInfo(false);
         fetch('/api/orders/SetEligibilityInfo', { method: 'POST',
           body: JSON.stringify({markdown: info}),
-          headers: {'Content-Type': "application/json", 'Authorization': token}
+          headers: {'Content-Type': "application/json", 'Authorization': authToken}
         }).then((res) => {
           console.log(res)
         })

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -1,12 +1,12 @@
 import Layout from "../components/Layout";
 import useSWR from "swr";
 import React from "react";
+import { useUser } from '../context/userContext'
 
 const fetcher = (url, token) =>
   fetch(url, {
     headers: { "Content-Type": "application/json", Authorization: token },
   }).then((res) => res.json());
-
 
 class PackingOrders extends React.Component {
   constructor(props) {
@@ -169,6 +169,7 @@ const createOrderObjects = (results) => {
 export default function PackingOverview() {
   const { user } = useUser();
   let authToken = (user && user.authorized) ? user.authToken : null;
+  const { data } = useSWR(["/api/orders/GetAllOrders/", authToken], fetcher);
 
   if (!authToken) {
     return (
@@ -178,7 +179,6 @@ export default function PackingOverview() {
     )
   }
   
-  const { data } = useSWR(["/api/orders/GetAllOrders/", authToken], fetcher);
   if (!data) {
     return <PackingOrders user={user} data={[]} key="emptyTable" />;
   } else {

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -173,9 +173,18 @@ const createOrderObjects = (results) => {
 };
 
 export default function PackingOverview() {
-  const { user } = useUser();
+  const { user, loadingUser } = useUser();
+
   let authToken = (user && user.authorized) ? user.authToken : null;
   const { data, error } = useSWR(["/api/orders/GetAllOrders/", authToken], fetcher);
+
+  if (loadingUser) {
+    return (
+      <Layout pageName="Checkout">
+          <h1 className='text-xl m-6'>Loading...</h1>
+      </Layout>
+    )
+  }
 
   if (error) {
     return (

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -3,10 +3,16 @@ import useSWR from "swr";
 import React from "react";
 import { useUser } from '../context/userContext'
 
-const fetcher = (url, token) =>
-  fetch(url, {
+const fetcher = async (url, token) => {
+  const res = await fetch(url, {
     headers: { "Content-Type": "application/json", Authorization: token },
-  }).then((res) => res.json());
+  });
+
+  if (res.status == 401) {
+    return Promise.reject("Sorry, you are not authorized to view this page.")
+  }
+  return res.json();
+}
 
 class PackingOrders extends React.Component {
   constructor(props) {
@@ -169,12 +175,12 @@ const createOrderObjects = (results) => {
 export default function PackingOverview() {
   const { user } = useUser();
   let authToken = (user && user.authorized) ? user.authToken : null;
-  const { data } = useSWR(["/api/orders/GetAllOrders/", authToken], fetcher);
+  const { data, error } = useSWR(["/api/orders/GetAllOrders/", authToken], fetcher);
 
-  if (!authToken) {
+  if (error) {
     return (
       <Layout pageName="Orders">
-          <h1 className='text-xl m-6'>Sorry, you are not authorized to view this page.</h1>
+          <h1 className='text-xl m-6'>{error}</h1>
       </Layout>
     )
   }

--- a/pages/packingDetailed.js
+++ b/pages/packingDetailed.js
@@ -13,16 +13,19 @@ import {
 
 function fetcher(token, ...urls) {
   const f = async (u) => {
-    const res = await fetch(u, {
-      headers: { "Content-Type": "application/json", Authorization: token },
-    });
-  
-    return res.json().then((resp) => {
-      if (!res.ok) {
-        return Promise.reject(resp)
-      }
-      return Promise.resolve(resp)
-    });
+    if (token) {
+      const res = await fetch(u, {
+        headers: { "Content-Type": "application/json", Authorization: token },
+      });
+
+      return res.json().then((resp) => {
+        if (!res.ok) {
+          return Promise.reject(resp)
+        }
+        return Promise.resolve(resp)
+      });
+    }
+    return Promise.resolve({})
   }
 
   if (urls.length > 1) {
@@ -51,7 +54,6 @@ class PackingOrder extends React.Component {
       error: null,
       success: null,
     };
-    
   }
 
   savePantryNote = (newPantryNote = this.state.pantryNote) => {
@@ -237,10 +239,15 @@ class PackingOrder extends React.Component {
     if (Object.entries(this.state.items).length > 0) {
       return (
         <tbody className="divide-y">
-          {Object.entries(this.state.items).map(([barcode, value]) =>
-            this.state.items[barcode].isPacked
+          {Object.entries(this.state.items).map(([barcode, value]) => {
+            if (this.state.items[barcode] == null) {
+              return null;
+            }
+
+            return this.state.items[barcode].isPacked
               ? this.displayPackedItemRow(barcode, value)
               : this.displayUnpackedItemRow(barcode, value)
+          }
           )}
         </tbody>
       );
@@ -338,7 +345,7 @@ class PackingOrder extends React.Component {
 }
 
 export default function PackingDetailed() {
-  const { user } = useUser();
+  const { user, loadingUser } = useUser();
   let authToken = (user && user.authorized) ? user.authToken : null;
 
   const router = useRouter();
@@ -355,6 +362,14 @@ export default function PackingDetailed() {
         <h1 className='text-xl m-6'>No Order Id provided</h1>
       </Layout>
     );
+  }
+
+  if (loadingUser) {
+    return (
+      <Layout pageName="Inventory">
+          <h1 className='text-xl m-6'>Loading...</h1>
+      </Layout>
+    )
   }
 
   if (error) {


### PR DESCRIPTION
will hopefully eliminate dependence on google cloud functions for user authorization, nd also get rid of 404/500 server errors on prod
- moves user storage from cookies into user context (slightly safer since we no longer depend on cookies)
- add "loading..." message when user hasn't loaded on page load (instead of "not authorized")
- removed the App.getInitialProps function in `pages/_app.js` that seems to be causing the 404 errors. apparently this may break CORS requests, but I don't think we're using any... TODO test every API to make sure

TODO:
- clean up checkout, checkin pages that had the override for authToken timeouts?
- test every API to make sure CORS requests (if there are any?) aren't causing issues