### PR TITLE
change validate api response to json

### DIFF
--- a/pages/api/validate.js
+++ b/pages/api/validate.js
@@ -33,29 +33,25 @@ export const validateFunc = async (token) => {
 };
 
 export default async (req, res) => {
-  try {
-    // Check if there is a token and if not return undefined.
-    
-    const { token } = JSON.parse(req.headers.authorization || '{}');
-    if (!token) {
-      return res.status(403).send({
-        errorCode: 403,
-        message: 'Auth token missing.',
-      });
-    }
-    // Call the validate function above that gets the user data
-    // this data ends up getting passed to every page's props
-    const authenticated = await validateFunc(token);
+  // Check if there is a token and if not return undefined.
+  const { token } = JSON.parse(req.headers.authorization || '{}');
+  if (!token) {
+    return res.status(403).json({
+      message: 'Auth token missing.'
+    });
+  }
+  
+  // Call the validate function above that gets the user data
+  // this data ends up getting passed to every page's props
+  validateFunc(token).then(() => {
     const result = {
       "user": {
         "Data": "Hello"
       },
     };
-    return res.status(200).send(JSON.stringify(result));
-  } catch (err) {
-    // Return undefined if there is no user. You may also send a different status or handle the error in any way that you wish.
-    console.log(err);
-    const result = undefined;
-    return res.status(200).send(result);
-  }
+    return res.status(200).json(result);
+  }).catch(err => {
+    console.log(err)
+    return res.status(403).json({message: "No user found."});
+  })
 };

--- a/pages/api/validate.js
+++ b/pages/api/validate.js
@@ -5,29 +5,27 @@ export const validateFunc = async (token) => {
   return new Promise((resolve, reject) => {
     // apparently getting headers that don't exist return "undefined" the string ¯\_(ツ)_/¯
     if (token === "undefined" || typeof token === "undefined") {
-      reject("No token provided")
-      return false
+      return reject("No token provided")
     }
     // get list of authorized users
-    admin.database().ref('/authorizedUser') 
+    admin.database().ref('/authorizedUser')
     .once('value', snapshot => {
       // check if the token is valid
       return admin.auth().verifyIdToken(token, true)
-      .catch(error => {
-        reject(error)
-        return false
-      })
       .then(decoded => {
         // the ID token is valid
         // now check if the user pulled from the token is authorized
         var vals = snapshot.val()
         for (const key in vals) {
           if (vals[key] === decoded.email && decoded.email_verified) {
-            resolve(true)
+            return resolve(true)
           }
         }
-        reject("Valid token but unallowed email")
-      })      
+        return reject("Valid token but unallowed email")
+      })
+      .catch(error => {
+        return reject(error)
+      })
     });
   })
 };

--- a/pages/api/validate.js
+++ b/pages/api/validate.js
@@ -1,7 +1,6 @@
 import admin from '../../utils/auth/firebaseAdmin'    
 
 export const validateFunc = async (token) => {
-  
   return new Promise((resolve, reject) => {
     // apparently getting headers that don't exist return "undefined" the string ¯\_(ツ)_/¯
     if (token === "undefined" || typeof token === "undefined") {
@@ -26,30 +25,30 @@ export const validateFunc = async (token) => {
       .catch(error => {
         return reject(error)
       })
+    })
+    .catch(error => {
+      return reject(error)
     });
   })
 };
 
-export default async (req, res) => {
+export default (req, res) => {
   // Check if there is a token and if not return undefined.
   const { token } = JSON.parse(req.headers.authorization || '{}');
+
   if (!token) {
     return res.status(403).json({
       message: 'Auth token missing.'
     });
   }
-  
+
   // Call the validate function above that gets the user data
   // this data ends up getting passed to every page's props
-  validateFunc(token).then(() => {
-    const result = {
-      "user": {
-        "Data": "Hello"
-      },
-    };
-    return res.status(200).json(result);
-  }).catch(err => {
-    console.log(err)
-    return res.status(403).json({message: "No user found."});
+  return validateFunc(token)
+  .then(() => {
+    return res.status(200).json({message: "Success!"});
+  })
+  .catch(err => {
+    return res.status(403).json({message: "No user found.", error: err});
   })
 };


### PR DESCRIPTION
pretty sure the cause of the 404 errors on prod site was because the validate endpoint returned non-json response, but we're try to parse it as json in _app.js

this should fix the 404 errors - will be testing to make sure this actually works