### PR TITLE
filter order items when single-item order gets iterpreted as array

### DIFF
--- a/pages/packingDetailed.js
+++ b/pages/packingDetailed.js
@@ -229,13 +229,11 @@ class PackingOrder extends React.Component {
       return (
         <tbody className="divide-y">
           {Object.entries(this.state.items).map(([barcode, value]) => {
-            if (this.state.items[barcode] == null) {
-              return null;
-            }
-
-            return this.state.items[barcode].isPacked
+            if (this.state.items[barcode] !== null) {
+              return this.state.items[barcode].isPacked
               ? this.displayPackedItemRow(barcode, value)
               : this.displayUnpackedItemRow(barcode, value)
+            }
           }
           )}
         </tbody>

--- a/pages/packingDetailed.js
+++ b/pages/packingDetailed.js
@@ -228,10 +228,15 @@ class PackingOrder extends React.Component {
     if (Object.entries(this.state.items).length > 0) {
       return (
         <tbody className="divide-y">
-          {Object.entries(this.state.items).map(([barcode, value]) =>
-            this.state.items[barcode].isPacked
+          {Object.entries(this.state.items).map(([barcode, value]) => {
+            if (this.state.items[barcode] == null) {
+              return null;
+            }
+
+            return this.state.items[barcode].isPacked
               ? this.displayPackedItemRow(barcode, value)
               : this.displayUnpackedItemRow(barcode, value)
+          }
           )}
         </tbody>
       );


### PR DESCRIPTION
for some reason, for orders that have a single item that has barcode 1, firebase is returning the items as an array, with a null entry at index 1 (so items looks like `[null, <item1>]`)

this is causing the bagpacking page display to fail - so i added a filter to the displayItemTable as a fix