### PR TITLE
Changed regex for 'isStudent' to allow 8 digit ids

### DIFF
--- a/pages/checkin.js
+++ b/pages/checkin.js
@@ -134,7 +134,8 @@ class Checkin extends React.Component {
 
   validateCalId = (calIdValue) => {
     const regexes = { 
-      'isStudent': /^(30\d{8}|[1278]\d{7})$/,
+      // old: 'isStudent': /^(30\d{8}|[1278]\d{7})$/,
+      'isStudent': /^\d{8}$/,
       'isEmployeeOrAffiliate': /^(01\d{6}|10\d{6})$/,
       'isValidEncrypted': /^810:\d{8}$/,
       'isCommunity': /^1$/

--- a/pages/checkinGrabnGo.js
+++ b/pages/checkinGrabnGo.js
@@ -124,7 +124,8 @@ class Checkin extends React.Component {
 
   validateCalId = (calIdValue) => {
     const regexes = { 
-      'isStudent': /^(30\d{8}|[1278]\d{7})$/,
+      // old: 'isStudent': /^(30\d{8}|[1278]\d{7})$/,
+      'isStudent': /^\d{8}$/,
       'isEmployeeOrAffiliate': /^(01\d{6}|10\d{6})$/,
       'isValidEncrypted': /^810:\d{8}$/,
       'isCommunity': /^1$/


### PR DESCRIPTION
commented out old 'isStudent' regex in pages/checkin.js and pages/checkinGrabnGo.js and replaced it to accept 8 digit id numbers